### PR TITLE
Add rotary table support for xArm6 simulation

### DIFF
--- a/ReadMe_en.md
+++ b/ReadMe_en.md
@@ -220,6 +220,9 @@ __Reminder 3： All following instructions will base on xArm6，please use prope
         # For xArm(xarm6 as example): set 'add_gripper=true' to attach xArm gripper model
         $ ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py [add_gripper:=true]
 
+        # xArm6 mounted on rotary table
+        $ ros2 launch xarm_moveit_config xarm6_table_moveit_fake.launch.py
+
         # For Lite6: set 'add_gripper=true' to attach Lite6 gripper model
         $ ros2 launch xarm_moveit_config lite6_moveit_fake.launch.py [add_gripper:=true]
         ```

--- a/xarm_controller/config/xarm_table6_controllers.yaml
+++ b/xarm_controller/config/xarm_table6_controllers.yaml
@@ -1,0 +1,38 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    xarm_table6_traj_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+xarm_table6_traj_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+      - velocity
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - table_joint
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+    constraints:
+      goal_time: 0.5
+      stopped_velocity_tolerance: 0.0
+      joint1: {trajectory: 1.0, goal: 0.01}
+      joint2: {trajectory: 1.0, goal: 0.01}
+      joint3: {trajectory: 1.0, goal: 0.01}
+      joint4: {trajectory: 1.0, goal: 0.01}
+      joint5: {trajectory: 1.0, goal: 0.01}
+      joint6: {trajectory: 1.0, goal: 0.01}
+    interface_name: position
+    state_publish_rate: 25.0
+    action_monitor_rate: 10.0

--- a/xarm_description/urdf/rotary_table/rotary_table_macro.xacro
+++ b/xarm_description/urdf/rotary_table/rotary_table_macro.xacro
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="rotary_table">
+  <xacro:macro name="rotary_table" params="prefix:='' joint_name:='table_joint' link_name:='table_link' xyz:='0 0 0' rpy:='0 0 0'">
+    <link name="${prefix}${link_name}">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1.0"/>
+        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder length="0.02" radius="0.1"/>
+        </geometry>
+        <material name="Grey">
+          <color rgba="0.6 0.6 0.6 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder length="0.02" radius="0.1"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}${joint_name}" type="revolute">
+      <origin xyz="${xyz}" rpy="${rpy}"/>
+      <parent link="world"/>
+      <child link="${prefix}${link_name}"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-3.1416" upper="3.1416" effort="10" velocity="1"/>
+    </joint>
+  </xacro:macro>
+</robot>

--- a/xarm_description/urdf/xarm6_table_device.urdf.xacro
+++ b/xarm_description/urdf/xarm6_table_device.urdf.xacro
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="xarm6_table">
+  <xacro:arg name="prefix" default=""/>
+  <xacro:arg name="hw_ns" default="xarm"/>
+  <xacro:arg name="limited" default="false"/>
+  <xacro:arg name="effort_control" default="false"/>
+  <xacro:arg name="velocity_control" default="false"/>
+  <xacro:arg name="add_gripper" default="false"/>
+  <xacro:arg name="add_vacuum_gripper" default="false"/>
+  <xacro:arg name="robot_type" default="xarm"/>
+  <xacro:arg name="ros2_control_plugin" default="uf_robot_hardware/UFRobotSystemHardware"/>
+  <xacro:arg name="ros2_control_params" default="$(find xarm_controller)/config/xarm_table6_controllers.yaml"/>
+
+  <xacro:arg name="add_other_geometry" default="false"/>
+  <xacro:arg name="geometry_type" default="box"/>
+  <xacro:arg name="geometry_mass" default="0.1"/>
+  <xacro:arg name="geometry_height" default="0.1"/>
+  <xacro:arg name="geometry_radius" default="0.1"/>
+  <xacro:arg name="geometry_length" default="0.1"/>
+  <xacro:arg name="geometry_width" default="0.1"/>
+  <xacro:arg name="geometry_mesh_filename" default=""/>
+  <xacro:arg name="geometry_mesh_origin_xyz" default="0 0 0"/>
+  <xacro:arg name="geometry_mesh_origin_rpy" default="0 0 0"/>
+  <xacro:arg name="geometry_mesh_tcp_xyz" default="0 0 0"/>
+  <xacro:arg name="geometry_mesh_tcp_rpy" default="0 0 0"/>
+
+  <xacro:arg name="robot_ip" default=""/>
+  <xacro:arg name="report_type" default="normal"/>
+  <xacro:arg name="baud_checkset" default="true"/>
+  <xacro:arg name="default_gripper_baud" default="2000000"/>
+
+  <xacro:include filename="$(find xarm_description)/urdf/rotary_table/rotary_table_macro.xacro"/>
+  <xacro:include filename="$(find xarm_description)/urdf/xarm_device_macro.xacro"/>
+
+  <link name="world" />
+
+  <xacro:rotary_table prefix="${prefix}" />
+
+  <xacro:xarm_device prefix="${prefix}" namespace="${hw_ns}" limited="${limited}"
+    effort_control="${effort_control}" velocity_control="${velocity_control}"
+    add_gripper="${add_gripper}" add_vacuum_gripper="${add_vacuum_gripper}" dof="6"
+    robot_type="${robot_type}" ros2_control_plugin="${ros2_control_plugin}"
+    load_gazebo_plugin="false" ros2_control_params="${ros2_control_params}"
+    attach_to="${prefix}table_link" xyz="0 0 0" rpy="0 0 0"
+    add_other_geometry="${add_other_geometry}"
+    geometry_type="${geometry_type}" geometry_mass="${geometry_mass}"
+    geometry_height="${geometry_height}" geometry_radius="${geometry_radius}"
+    geometry_length="${geometry_length}" geometry_width="${geometry_width}"
+    geometry_mesh_filename="${geometry_mesh_filename}"
+    geometry_mesh_origin_xyz="${geometry_mesh_origin_xyz}" geometry_mesh_origin_rpy="${geometry_mesh_origin_rpy}"
+    geometry_mesh_tcp_xyz="${geometry_mesh_tcp_xyz}" geometry_mesh_tcp_rpy="${geometry_mesh_tcp_rpy}"
+    robot_ip="${robot_ip}" report_type="${report_type}"
+    baud_checkset="${baud_checkset}" default_gripper_baud="${default_gripper_baud}"/>
+</robot>

--- a/xarm_moveit_config/config/xarm_table6/controllers.yaml
+++ b/xarm_moveit_config/config/xarm_table6/controllers.yaml
@@ -1,0 +1,15 @@
+controller_names:
+  - xarm_table6_traj_controller
+
+xarm_table6_traj_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - table_joint
+    - joint1
+    - joint2
+    - joint3
+    - joint4
+    - joint5
+    - joint6

--- a/xarm_moveit_config/config/xarm_table6/fake_controllers.yaml
+++ b/xarm_moveit_config/config/xarm_table6/fake_controllers.yaml
@@ -1,0 +1,15 @@
+controller_names:
+  - xarm_table6_traj_controller
+
+xarm_table6_traj_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - table_joint
+    - joint1
+    - joint2
+    - joint3
+    - joint4
+    - joint5
+    - joint6

--- a/xarm_moveit_config/config/xarm_table6/joint_limits.yaml
+++ b/xarm_moveit_config/config/xarm_table6/joint_limits.yaml
@@ -1,0 +1,39 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
+joint_limits:
+  table_joint:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint1:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint2:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint3:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint4:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint5:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  joint6:
+    has_velocity_limits: true
+    max_velocity: 2.14
+    has_acceleration_limits: false
+    max_acceleration: 0.0

--- a/xarm_moveit_config/config/xarm_table6/kinematics.yaml
+++ b/xarm_moveit_config/config/xarm_table6/kinematics.yaml
@@ -1,0 +1,6 @@
+xarm6_table:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  # kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3

--- a/xarm_moveit_config/config/xarm_table6/ompl_planning.yaml
+++ b/xarm_moveit_config/config/xarm_table6/ompl_planning.yaml
@@ -1,0 +1,148 @@
+planner_configs:
+  SBL:
+    type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  EST:
+    type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+  LBKPIECE:
+    type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  BKPIECE:
+    type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  KPIECE:
+    type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  RRT:
+    type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+  RRTConnect:
+    type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  RRTstar:
+    type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
+  TRRT:
+    type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
+  PRM:
+    type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
+  PRMstar:
+    type: geometric::PRMstar
+  FMT:
+    type: geometric::FMT
+    num_samples: 1000  # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.1  # multiplier used for the nearest neighbors search radius. default: 1.1
+    nearest_k: 1  # use Knearest strategy. default: 1
+    cache_cc: 1  # use collision checking cache. default: 1
+    heuristics: 0  # activate cost to go heuristics. default: 0
+    extended_fmt: 1  # activate the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  BFMT:
+    type: geometric::BFMT
+    num_samples: 1000  # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.0  # multiplier used for the nearest neighbors search radius. default: 1.0
+    nearest_k: 1  # use the Knearest strategy. default: 1
+    balanced: 0  # exploration strategy: balanced true expands one tree every iteration. False will select the tree with lowest maximum cost to go. default: 1
+    optimality: 1  # termination strategy: optimality true finishes when the best possible path is found. Otherwise, the algorithm will finish when the first feasible path is found. default: 1
+    heuristics: 1  # activates cost to go heuristics. default: 1
+    cache_cc: 1  # use the collision checking cache. default: 1
+    extended_fmt: 1  # Activates the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  PDST:
+    type: geometric::PDST
+  STRIDE:
+    type: geometric::STRIDE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    use_projected_distance: 0  # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
+    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
+    max_degree: 18  # max degree of a node in the GNAT. default: 12
+    min_degree: 12  # min degree of a node in the GNAT. default: 12
+    max_pts_per_leaf: 6  # max points per leaf in the GNAT. default: 6
+    estimated_dimension: 0.0  # estimated dimension of the free space. default: 0.0
+    min_valid_path_fraction: 0.2  # Accept partially valid moves above fraction. default: 0.2
+  BiTRRT:
+    type: geometric::BiTRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
+    init_temperature: 100  # initial temperature. default: 100
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
+  LBTRRT:
+    type: geometric::LBTRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    epsilon: 0.4  # optimality approximation factor. default: 0.4
+  BiEST:
+    type: geometric::BiEST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  ProjEST:
+    type: geometric::ProjEST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+  LazyPRM:
+    type: geometric::LazyPRM
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  LazyPRMstar:
+    type: geometric::LazyPRMstar
+  SPARS:
+    type: geometric::SPARS
+    stretch_factor: 3.0  # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
+    max_failures: 1000  # maximum consecutive failure limit. default: 1000
+  SPARStwo:
+    type: geometric::SPARStwo
+    stretch_factor: 3.0  # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
+    max_failures: 5000  # maximum consecutive failure limit. default: 5000
+
+xarm7:
+  planner_configs:
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo

--- a/xarm_moveit_config/launch/_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_common.launch.py
@@ -48,18 +48,26 @@ def launch_setup(context, *args, **kwargs):
     geometry_mesh_tcp_xyz = LaunchConfiguration('geometry_mesh_tcp_xyz', default='"0 0 0"')
     geometry_mesh_tcp_rpy = LaunchConfiguration('geometry_mesh_tcp_rpy', default='"0 0 0"')
 
+    xacro_urdf_file = LaunchConfiguration('xacro_urdf_file',
+        default=PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm_device.urdf.xacro']))
+    xacro_srdf_file = LaunchConfiguration('xacro_srdf_file',
+        default=PathJoinSubstitution([FindPackageShare('xarm_moveit_config'), 'srdf', 'xarm.srdf.xacro']))
+    xarm_type_arg = LaunchConfiguration('xarm_type', default='')
+
     use_sim_time = LaunchConfiguration('use_sim_time', default=False)
 
     moveit_config_package_name = 'xarm_moveit_config'
-    xarm_type = '{}{}'.format(robot_type.perform(context), dof.perform(context))
+    xarm_type = xarm_type_arg.perform(context)
+    if not xarm_type:
+        xarm_type = '{}{}'.format(robot_type.perform(context), dof.perform(context))
 
     # robot_description_parameters
     # xarm_moveit_config/launch/lib/robot_moveit_config_lib.py
     mod = load_python_launch_file_as_module(os.path.join(get_package_share_directory(moveit_config_package_name), 'launch', 'lib', 'robot_moveit_config_lib.py'))
     get_xarm_robot_description_parameters = getattr(mod, 'get_xarm_robot_description_parameters')
     robot_description_parameters = get_xarm_robot_description_parameters(
-        xacro_urdf_file=PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm_device.urdf.xacro']),
-        xacro_srdf_file=PathJoinSubstitution([FindPackageShare('xarm_moveit_config'), 'srdf', 'xarm.srdf.xacro']),
+        xacro_urdf_file=xacro_urdf_file,
+        xacro_srdf_file=xacro_srdf_file,
         urdf_arguments={
             'prefix': prefix,
             'hw_ns': hw_ns.perform(context).strip('/'),

--- a/xarm_moveit_config/launch/_robot_moveit_fake.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_fake.launch.py
@@ -39,11 +39,20 @@ def launch_setup(context, *args, **kwargs):
     geometry_mesh_tcp_xyz = LaunchConfiguration('geometry_mesh_tcp_xyz', default='"0 0 0"')
     geometry_mesh_tcp_rpy = LaunchConfiguration('geometry_mesh_tcp_rpy', default='"0 0 0"')
 
+    xacro_file = LaunchConfiguration('xacro_file',
+        default=PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm_device.urdf.xacro']))
+    xacro_urdf_file = LaunchConfiguration('xacro_urdf_file', default=xacro_file)
+    xacro_srdf_file = LaunchConfiguration('xacro_srdf_file',
+        default=PathJoinSubstitution([FindPackageShare('xarm_moveit_config'), 'srdf', 'xarm.srdf.xacro']))
+    xarm_type_arg = LaunchConfiguration('xarm_type', default='')
+
     ros2_control_plugin = 'uf_robot_hardware/UFRobotFakeSystemHardware'
     controllers_name = 'fake_controllers'
     moveit_controller_manager_key = 'moveit_simple_controller_manager'
     moveit_controller_manager_value = 'moveit_simple_controller_manager/MoveItSimpleControllerManager'
-    xarm_type = '{}{}'.format(robot_type.perform(context), dof.perform(context))
+    xarm_type = xarm_type_arg.perform(context)
+    if not xarm_type:
+        xarm_type = '{}{}'.format(robot_type.perform(context), dof.perform(context))
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
     
     # robot description launch
@@ -74,6 +83,7 @@ def launch_setup(context, *args, **kwargs):
             'geometry_mesh_origin_rpy': geometry_mesh_origin_rpy,
             'geometry_mesh_tcp_xyz': geometry_mesh_tcp_xyz,
             'geometry_mesh_tcp_rpy': geometry_mesh_tcp_rpy,
+            'xacro_file': xacro_file,
         }.items(),
     )
 
@@ -109,6 +119,9 @@ def launch_setup(context, *args, **kwargs):
             'geometry_mesh_origin_rpy': geometry_mesh_origin_rpy,
             'geometry_mesh_tcp_xyz': geometry_mesh_tcp_xyz,
             'geometry_mesh_tcp_rpy': geometry_mesh_tcp_rpy,
+            'xacro_urdf_file': xacro_urdf_file,
+            'xacro_srdf_file': xacro_srdf_file,
+            'xarm_type': xarm_type,
         }.items(),
     )
 
@@ -158,6 +171,7 @@ def launch_setup(context, *args, **kwargs):
             'geometry_mesh_origin_rpy': geometry_mesh_origin_rpy,
             'geometry_mesh_tcp_xyz': geometry_mesh_tcp_xyz,
             'geometry_mesh_tcp_rpy': geometry_mesh_tcp_rpy,
+            'xacro_file': xacro_file,
         }.items(),
     )
 

--- a/xarm_moveit_config/launch/xarm6_table_moveit_fake.launch.py
+++ b/xarm_moveit_config/launch/xarm6_table_moveit_fake.launch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2021, UFACTORY, Inc.
+# All rights reserved.
+#
+# Author: Vinman <vinman.wen@ufactory.cc> <vinman.cub@gmail.com>
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    prefix = LaunchConfiguration('prefix', default='')
+    hw_ns = LaunchConfiguration('hw_ns', default='xarm')
+    limited = LaunchConfiguration('limited', default=True)
+    effort_control = LaunchConfiguration('effort_control', default=False)
+    velocity_control = LaunchConfiguration('velocity_control', default=False)
+    add_gripper = LaunchConfiguration('add_gripper', default=False)
+    add_vacuum_gripper = LaunchConfiguration('add_vacuum_gripper', default=False)
+
+    add_other_geometry = LaunchConfiguration('add_other_geometry', default=False)
+    geometry_type = LaunchConfiguration('geometry_type', default='box')
+    geometry_mass = LaunchConfiguration('geometry_mass', default=0.1)
+    geometry_height = LaunchConfiguration('geometry_height', default=0.1)
+    geometry_radius = LaunchConfiguration('geometry_radius', default=0.1)
+    geometry_length = LaunchConfiguration('geometry_length', default=0.1)
+    geometry_width = LaunchConfiguration('geometry_width', default=0.1)
+    geometry_mesh_filename = LaunchConfiguration('geometry_mesh_filename', default='')
+    geometry_mesh_origin_xyz = LaunchConfiguration('geometry_mesh_origin_xyz', default='"0 0 0"')
+    geometry_mesh_origin_rpy = LaunchConfiguration('geometry_mesh_origin_rpy', default='"0 0 0"')
+    geometry_mesh_tcp_xyz = LaunchConfiguration('geometry_mesh_tcp_xyz', default='"0 0 0"')
+    geometry_mesh_tcp_rpy = LaunchConfiguration('geometry_mesh_tcp_rpy', default='"0 0 0"')
+
+    # robot moveit fake launch
+    # xarm_moveit_config/launch/_robot_moveit_fake.launch.py
+    robot_moveit_fake_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('xarm_moveit_config'), 'launch', '_robot_moveit_fake.launch.py'])),
+        launch_arguments={
+            'prefix': prefix,
+            'hw_ns': hw_ns,
+            'limited': limited,
+            'effort_control': effort_control,
+            'velocity_control': velocity_control,
+            'add_gripper': add_gripper,
+            'add_vacuum_gripper': add_vacuum_gripper,
+            'dof': '6',
+            'robot_type': 'xarm_table',
+            'xacro_file': PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm6_table_device.urdf.xacro']),
+            'xacro_urdf_file': PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm6_table_device.urdf.xacro']),
+            'xacro_srdf_file': PathJoinSubstitution([FindPackageShare('xarm_moveit_config'), 'srdf', 'xarm_table.srdf.xacro']),
+            'xarm_type': 'xarm_table6',
+            'no_gui_ctrl': 'false',
+            'add_other_geometry': add_other_geometry,
+            'geometry_type': geometry_type,
+            'geometry_mass': geometry_mass,
+            'geometry_height': geometry_height,
+            'geometry_radius': geometry_radius,
+            'geometry_length': geometry_length,
+            'geometry_width': geometry_width,
+            'geometry_mesh_filename': geometry_mesh_filename,
+            'geometry_mesh_origin_xyz': geometry_mesh_origin_xyz,
+            'geometry_mesh_origin_rpy': geometry_mesh_origin_rpy,
+            'geometry_mesh_tcp_xyz': geometry_mesh_tcp_xyz,
+            'geometry_mesh_tcp_rpy': geometry_mesh_tcp_rpy,
+        }.items(),
+    )
+    
+    return LaunchDescription([
+        robot_moveit_fake_launch
+    ])

--- a/xarm_moveit_config/srdf/_xarm6_table_macro.srdf.xacro
+++ b/xarm_moveit_config/srdf/_xarm6_table_macro.srdf.xacro
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This does not replace URDF, and is not an extension of URDF.
+  This is a format for representing semantic information about the robot structure.
+  A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined -->
+
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="xarm6_srdf">
+  <!-- GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc -->
+  <!-- LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included -->
+  <!-- JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included -->
+  <!-- CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group -->
+  <!-- SUBGROUPS: Groups can also be formed by referencing to already defined group names -->
+  <xacro:macro name="xarm6_table_macro_srdf" params="prefix='' 
+    add_gripper='false' add_vacuum_gripper='false' add_other_geometry='false' ">
+    <group name="${prefix}xarm6_table">
+      <joint name="${prefix}world_joint" />
+      <joint name="${prefix}table_joint" />
+      <joint name="${prefix}joint1" />
+      <joint name="${prefix}joint2" />
+      <joint name="${prefix}joint3" />
+      <joint name="${prefix}joint4" />
+      <joint name="${prefix}joint5" />
+      <joint name="${prefix}joint6" />
+      <joint name="${prefix}joint_eef" />
+      <!-- To count in gripper TCP offset, if no need, please uncomment following 2 lines -->
+      <xacro:if value="${add_gripper}">
+        <joint name="${prefix}gripper_fix" />
+        <joint name="${prefix}joint_tcp" />
+      </xacro:if>
+      <xacro:if value="${not add_gripper and add_vacuum_gripper}">
+        <joint name="${prefix}vacuum_gripper_fix" />
+        <joint name="${prefix}joint_tcp" />
+      </xacro:if>
+      <xacro:if value="${not add_gripper and not add_vacuum_gripper and add_other_geometry}">
+        <joint name="${prefix}other_geometry_fix" />
+        <joint name="${prefix}joint_tcp" />
+      </xacro:if>
+    </group>
+    <!-- GROUP STATES, Purpose, Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms' -->
+    <group_state name="home" group="${prefix}xarm6_table">
+      <joint name="${prefix}joint1" value="0" />
+      <joint name="${prefix}table_joint" value="0" />
+      <joint name="${prefix}joint2" value="0" />
+      <joint name="${prefix}joint3" value="0" />
+      <joint name="${prefix}joint4" value="0" />
+      <joint name="${prefix}joint5" value="0" />
+      <joint name="${prefix}joint6" value="0" />
+    </group_state>
+    <group_state name="hold-up" group="${prefix}xarm6_table">
+        <joint name="${prefix}table_joint" value="0" />
+      <joint name="${prefix}joint1" value="0" />
+      <joint name="${prefix}joint2" value="0" />
+      <joint name="${prefix}joint3" value="0" />
+      <joint name="${prefix}joint4" value="0" />
+      <joint name="${prefix}joint5" value="-1.5708" />
+      <joint name="${prefix}joint6" value="0" />
+    </group_state>
+
+    <!-- gripper -->
+    <xacro:if value="${add_gripper}">
+      <group name="${prefix}xarm_gripper">
+        <link name="${prefix}xarm_gripper_base_link" />
+        <link name="${prefix}left_outer_knuckle" />
+        <link name="${prefix}left_finger" />
+        <link name="${prefix}left_inner_knuckle" />
+        <link name="${prefix}right_inner_knuckle" />
+        <link name="${prefix}right_outer_knuckle" />
+        <link name="${prefix}right_finger" />
+        <link name="${prefix}link_tcp" />
+        <joint name="${prefix}drive_joint" />
+      </group>
+      <group_state name="open" group="${prefix}xarm_gripper">
+        <joint name="${prefix}drive_joint" value="0" />
+      </group_state>
+      <group_state name="close" group="${prefix}xarm_gripper">
+        <joint name="${prefix}drive_joint" value="0.85" />
+      </group_state>
+      <!-- END EFFECTOR, Purpose, Represent information about an end effector. -->
+      <end_effector name="${prefix}xarm_gripper" parent_link="${prefix}link_tcp" group="${prefix}xarm_gripper" />
+      <!--PASSIVE JOINT, Purpose, this element is used to mark joints that are not actuated-->
+      <passive_joint name="${prefix}left_finger_joint" />
+      <passive_joint name="${prefix}left_inner_knuckle_joint" />
+      <passive_joint name="${prefix}right_inner_knuckle_joint" />
+      <passive_joint name="${prefix}right_outer_knuckle_joint" />
+      <passive_joint name="${prefix}right_finger_joint" />
+      <!-- DISABLE COLLISIONS, By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}left_inner_knuckle" reason="Default" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}left_outer_knuckle" reason="Adjacent" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}link4" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}link5" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}link6" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_finger" link2="${prefix}xarm_gripper_base_link" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}left_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}link4" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}link5" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}link6" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_inner_knuckle" link2="${prefix}xarm_gripper_base_link" reason="Adjacent" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}link5" reason="Never" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}link6" reason="Never" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}left_outer_knuckle" link2="${prefix}xarm_gripper_base_link" reason="Adjacent" />
+
+      <disable_collisions link1="${prefix}link4" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}link4" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}link6" reason="Adjacent" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}xarm_gripper_base_link" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}right_finger" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}right_inner_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}xarm_gripper_base_link" reason="Adjacent" />
+      <disable_collisions link1="${prefix}right_finger" link2="${prefix}right_inner_knuckle" reason="Default" />
+      <disable_collisions link1="${prefix}right_finger" link2="${prefix}right_outer_knuckle" reason="Adjacent" />
+      <disable_collisions link1="${prefix}right_finger" link2="${prefix}xarm_gripper_base_link" reason="Never" />
+      <disable_collisions link1="${prefix}right_inner_knuckle" link2="${prefix}right_outer_knuckle" reason="Never" />
+      <disable_collisions link1="${prefix}right_inner_knuckle" link2="${prefix}xarm_gripper_base_link" reason="Adjacent" />
+      <disable_collisions link1="${prefix}right_outer_knuckle" link2="${prefix}xarm_gripper_base_link" reason="Adjacent" />
+    </xacro:if>
+
+    <!-- vacuum gripper -->
+    <xacro:if value="${not add_gripper and add_vacuum_gripper}">
+      <!-- <group name="${prefix}vacuum_gripper">
+        <joint name="${prefix}vacuum_gripper_fix" />
+      </group> -->
+      <!-- <end_effector name="${prefix}vacuum_gripper" parent_link="${prefix}link_tcp" group="${prefix}vacuum_gripper" /> -->
+      <passive_joint name="${prefix}vacuum_gripper_fix" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}xarm_vacuum_gripper_link" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}xarm_vacuum_gripper_link" reason="Adjacent" />
+    </xacro:if>
+
+    <!-- other box -->
+    <xacro:if value="${not add_gripper and not add_vacuum_gripper and add_other_geometry}">
+      <!-- <group name="${prefix}other_geometry">
+        <joint name="${prefix}other_geometry_fix" />
+      </group> -->
+      <!-- <end_effector name="${prefix}other_geometry" parent_link="${prefix}link_tcp" group="${prefix}other_geometry" /> -->
+      <passive_joint name="${prefix}other_geometry_fix" />
+      <disable_collisions link1="${prefix}link5" link2="${prefix}other_geometry_link" reason="Never" />
+      <disable_collisions link1="${prefix}link6" link2="${prefix}other_geometry_link" reason="Adjacent" />
+    </xacro:if>
+
+    <disable_collisions link1="${prefix}link1" link2="${prefix}link2" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link1" link2="${prefix}link3" reason="Never" />
+    <disable_collisions link1="${prefix}link1" link2="${prefix}link_base" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link2" link2="${prefix}link3" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link2" link2="${prefix}link4" reason="Never" />
+    <disable_collisions link1="${prefix}link2" link2="${prefix}link_base" reason="Never" />
+    <disable_collisions link1="${prefix}link3" link2="${prefix}link4" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link3" link2="${prefix}link5" reason="Never" />
+    <disable_collisions link1="${prefix}link3" link2="${prefix}link6" reason="Never" />
+    <disable_collisions link1="${prefix}link4" link2="${prefix}link5" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link4" link2="${prefix}link6" reason="Never" />
+    <disable_collisions link1="${prefix}link5" link2="${prefix}link6" reason="Adjacent" />
+  </xacro:macro>
+</robot>

--- a/xarm_moveit_config/srdf/xarm_table.srdf.xacro
+++ b/xarm_moveit_config/srdf/xarm_table.srdf.xacro
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="xarm_table">
+  <xacro:arg name="prefix" default="" />
+  <xacro:arg name="add_gripper" default="false"/>
+  <xacro:arg name="add_vacuum_gripper" default="false" />
+  <xacro:arg name="add_other_geometry" default="false" />
+
+  <xacro:include filename="$(find xarm_moveit_config)/srdf/_xarm6_table_macro.srdf.xacro" />
+  <xacro:xarm6_table_macro_srdf prefix="$(arg prefix)" add_gripper="$(arg add_gripper)" add_vacuum_gripper="$(arg add_vacuum_gripper)" add_other_geometry="$(arg add_other_geometry)"/>
+</robot>


### PR DESCRIPTION
## Summary
- add rotary_table macro and xarm6_table device URDF
- create SRDF macros and configs for xarm6 with rotary table
- allow MoveIt launch files to override xacro files and xarm_type
- add launch file for xarm6_table MoveIt fake demo
- document how to run the new demo

## Testing
- `colcon build --packages-select xarm_moveit_config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824b2571b48321881a02bf593d3ed4