### PR TITLE
Add 7‑DOF planning support for rotary table

### DIFF
--- a/xarm_moveit_config/config/xarm6/joint_limits.yaml
+++ b/xarm_moveit_config/config/xarm6/joint_limits.yaml
@@ -32,3 +32,8 @@ joint_limits:
     max_velocity: 2.14
     has_acceleration_limits: true
     max_acceleration: 10.0
+  rotary_table_joint:
+    has_velocity_limits: true
+    max_velocity: 1.0
+    has_acceleration_limits: true
+    max_acceleration: 10.0

--- a/xarm_moveit_config/config/xarm6/kinematics.yaml
+++ b/xarm_moveit_config/config/xarm6/kinematics.yaml
@@ -4,3 +4,9 @@ xarm6:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+
+xarm_with_rotary:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3

--- a/xarm_moveit_config/config/xarm6/ompl_planning.yaml
+++ b/xarm_moveit_config/config/xarm6/ompl_planning.yaml
@@ -25,6 +25,33 @@ xarm6:
     - SPARS
     - SPARStwo
 
+xarm_with_rotary:
+  default_planner_config: RRTConnect
+  planner_configs:
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo
+
 dual_arm:
   default_planner_config: RRTConnect
   planner_configs:

--- a/xarm_moveit_config/launch/single_xarm_rotary_moveit_fake.launch.py
+++ b/xarm_moveit_config/launch/single_xarm_rotary_moveit_fake.launch.py
@@ -83,7 +83,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # ───────────────── MoveIt config ──────────────────────
-    moveit_config = MoveItConfigsBuilder(
+    moveit_builder = MoveItConfigsBuilder(
         context=context,
         controllers_name=controllers_name,
         dof=dof,
@@ -115,7 +115,14 @@ def launch_setup(context, *args, **kwargs):
         geometry_mesh_origin_rpy=geometry_mesh_origin_rpy,
         geometry_mesh_tcp_xyz=geometry_mesh_tcp_xyz,
         geometry_mesh_tcp_rpy=geometry_mesh_tcp_rpy,
-    ).to_moveit_configs()
+    )
+
+    moveit_builder.robot_description(
+        file_path='urdf/single_xarm_with_rotary.urdf.xacro')
+    moveit_builder.robot_description_semantic(
+        file_path='srdf/xarm_with_rotary_table.srdf')
+
+    moveit_config = moveit_builder.to_moveit_configs()
 
     # ───────────────── nodes & includes ───────────────────
     # One static transform publisher so downstream common-launch files


### PR DESCRIPTION
## Summary
- load the combined arm+rotary URDF/SRDF in `single_xarm_rotary_moveit_fake.launch.py`
- extend kinematics config with `xarm_with_rotary` group
- add `xarm_with_rotary` section to OMPL planning config
- include rotary table joint in joint limits

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `colcon test --packages-select xarm_moveit_config --event-handlers console_cohesion+ --return-code-on-error` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826dc10868832183e745c70d6755d2