### PR TITLE
Fix single rotary table MoveIt configuration

### DIFF
--- a/xarm_moveit_config/launch/single_xarm_rotary_moveit_fake.launch.py
+++ b/xarm_moveit_config/launch/single_xarm_rotary_moveit_fake.launch.py
@@ -22,6 +22,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
+from pathlib import Path
 
 from uf_ros_lib.moveit_configs_builder import MoveItConfigsBuilder
 from uf_ros_lib.uf_robot_utils import generate_ros2_control_params_temp_file
@@ -117,8 +118,9 @@ def launch_setup(context, *args, **kwargs):
         geometry_mesh_tcp_rpy=geometry_mesh_tcp_rpy,
     )
 
-    moveit_builder.robot_description(
-        file_path='urdf/single_xarm_with_rotary.urdf.xacro')
+    # Use the rotary-table URDF residing in the xarm_description package
+    moveit_builder._MoveItConfigsBuilder__urdf_file_path = Path('urdf/single_xarm_with_rotary.urdf.xacro')
+    moveit_builder.robot_description()
     moveit_builder.robot_description_semantic(
         file_path='srdf/xarm_with_rotary_table.srdf')
 

--- a/xarm_moveit_config/srdf/xarm_with_rotary_table.srdf
+++ b/xarm_moveit_config/srdf/xarm_with_rotary_table.srdf
@@ -1,9 +1,8 @@
-<robot name="xarm6_with_rotary_table" xmlns="http://www.ros.org/schema/srdf" version="1.0">
+<robot name="XARM_WITH_ROTARY" xmlns="http://www.ros.org/schema/srdf" version="1.0">
 
   <!-- The full planning group -->
   <group name="xarm_with_rotary">
-    <chain base_link="link_base" tip_link="link_eef"/>
-    <joint name="rotary_table_joint"/>
+    <chain base_link="rotary_stand" tip_link="link_eef"/>
   </group>
 
   <!-- For legacy compatibility, original xarm6 group -->
@@ -15,7 +14,7 @@
   <end_effector name="xarm_gripper" parent_link="link_eef" group="xarm6"/>
 
   <!-- Virtual joints -->
-  <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="link_base"/>
+  <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="rotary_stand"/>
 
   <!-- Disable collision checking for adjacent links -->
   <disable_collisions link1="link_base" link2="link1" reason="Adjacent"/>


### PR DESCRIPTION
## Summary
- update SRDF for rotary table robot to match the URDF
- ensure the URDF for the rotary-table system is loaded from `xarm_description`

## Testing
- `colcon build --packages-select xarm_moveit_config` *(fails: command not found)*
- `colcon test --packages-select xarm_moveit_config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688947045a948321915f055081d6b741