### PR TITLE
Add optional workcell walls and launch toggle

### DIFF
--- a/xarm_controller/launch/_ros2_control.launch.py
+++ b/xarm_controller/launch/_ros2_control.launch.py
@@ -57,6 +57,7 @@ def launch_setup(context, *args, **kwargs):
     geometry_mesh_origin_rpy = LaunchConfiguration('geometry_mesh_origin_rpy', default='"0 0 0"')
     geometry_mesh_tcp_xyz = LaunchConfiguration('geometry_mesh_tcp_xyz', default='"0 0 0"')
     geometry_mesh_tcp_rpy = LaunchConfiguration('geometry_mesh_tcp_rpy', default='"0 0 0"')
+    add_walls = LaunchConfiguration('add_walls', default=False)
 
     kinematics_suffix = LaunchConfiguration('kinematics_suffix', default='')
     
@@ -115,6 +116,7 @@ def launch_setup(context, *args, **kwargs):
                 geometry_mesh_origin_rpy=geometry_mesh_origin_rpy,
                 geometry_mesh_tcp_xyz=geometry_mesh_tcp_xyz,
                 geometry_mesh_tcp_rpy=geometry_mesh_tcp_rpy,
+                add_walls=add_walls,
             )
         }
     else:

--- a/xarm_description/urdf/workcell_walls.urdf.xacro
+++ b/xarm_description/urdf/workcell_walls.urdf.xacro
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="workcell_walls">
+  <xacro:macro name="workcell_walls" params="prefix:=''">
+    <link name="${prefix}floor">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.91 0.61 0.005"/>
+        </geometry>
+        <material name="grey">
+          <color rgba="0.5 0.5 0.5 1"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.91 0.61 0.005"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="${prefix}back_wall">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="1.51 0.005 1.5"/>
+        </geometry>
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="1.51 0.005 1.5"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="${prefix}left_wall">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.005 1.51 1.5"/>
+        </geometry>
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.005 1.51 1.5"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="${prefix}right_wall">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.005 1.51 1.5"/>
+        </geometry>
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.005 1.51 1.5"/>
+        </geometry>
+      </collision>
+    </link>
+  </xacro:macro>
+</robot>

--- a/xarm_description/urdf/xarm_device.urdf.xacro
+++ b/xarm_description/urdf/xarm_device.urdf.xacro
@@ -42,6 +42,8 @@
   <xacro:arg name="geometry_mesh_tcp_xyz" default="0 0 0"/>
   <xacro:arg name="geometry_mesh_tcp_rpy" default="0 0 0"/>
 
+  <xacro:arg name="add_walls" default="false"/>
+
   <xacro:arg name="baud_checkset" default="true"/>
   <xacro:arg name="default_gripper_baud" default="2000000"/>
 
@@ -60,6 +62,7 @@
 
   <!-- ‣‣‣ xArm include (unchanged) -->
   <xacro:include filename="$(find xarm_description)/urdf/xarm_device_macro.xacro" />
+  <xacro:include filename="$(find xarm_description)/urdf/workcell_walls.urdf.xacro" />
   <xacro:xarm_device prefix="$(arg prefix)" hw_ns="$(arg hw_ns)" limited="$(arg limited)"
     effort_control="$(arg effort_control)" velocity_control="$(arg velocity_control)"
     add_gripper="$(arg add_gripper)" add_vacuum_gripper="$(arg add_vacuum_gripper)"
@@ -147,6 +150,30 @@
     <axis xyz="0 0 1"/>
     <limit lower="-3.14159" upper="3.14159" effort="20" velocity="1.5"/>
   </joint>
+
+  <xacro:if value="${add_walls}">
+    <xacro:workcell_walls/>
+    <joint name="floor_joint" type="fixed">
+      <parent link="world"/>
+      <child  link="floor"/>
+      <origin xyz="0.355 -0.205 -0.0025" rpy="0 0 0"/>
+    </joint>
+    <joint name="back_wall_joint" type="fixed">
+      <parent link="world"/>
+      <child  link="back_wall"/>
+      <origin xyz="0.3825 0.5425 0.75" rpy="0 0 0"/>
+    </joint>
+    <joint name="left_wall_joint" type="fixed">
+      <parent link="world"/>
+      <child  link="left_wall"/>
+      <origin xyz="-0.4225 -0.2125 0.75" rpy="0 0 0"/>
+    </joint>
+    <joint name="right_wall_joint" type="fixed">
+      <parent link="world"/>
+      <child  link="right_wall"/>
+      <origin xyz="1.3375 -0.2125 0.75" rpy="0 0 0"/>
+    </joint>
+  </xacro:if>
 
   <!-- ros2_control specification for the rotary joint (fake hardware) -->
   <ros2_control name="RotaryTableHW" type="system">

--- a/xarm_moveit_config/launch/single_xarm_rotary_moveit_realmove.launch.py
+++ b/xarm_moveit_config/launch/single_xarm_rotary_moveit_realmove.launch.py
@@ -75,6 +75,8 @@ def launch_setup(context, *args, **kwargs):
     geometry_mesh_tcp_xyz     = LaunchConfiguration('geometry_mesh_tcp_xyz',     default='"0 0 0"')
     geometry_mesh_tcp_rpy     = LaunchConfiguration('geometry_mesh_tcp_rpy',     default='"0 0 0"')
 
+    add_walls = LaunchConfiguration('add_walls', default=False)
+
     # ───────────────── misc ───────────────────────────────
     no_gui_ctrl   = LaunchConfiguration('no_gui_ctrl', default=False)
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
@@ -136,6 +138,7 @@ def launch_setup(context, *args, **kwargs):
         geometry_mesh_origin_rpy=geometry_mesh_origin_rpy,
         geometry_mesh_tcp_xyz=geometry_mesh_tcp_xyz,
         geometry_mesh_tcp_rpy=geometry_mesh_tcp_rpy,
+        add_walls=add_walls,
     )
 
     # moveit_builder.robot_description(
@@ -191,7 +194,8 @@ def launch_setup(context, *args, **kwargs):
         ])),
         launch_arguments={
             'robot_description': yaml.dump(moveit_config.robot_description),
-            'ros2_control_params': ros2_control_params
+            'ros2_control_params': ros2_control_params,
+            'add_walls': add_walls
             # 'xacro_file': LaunchConfiguration('xacro_file', default=PathJoinSubstitution([FindPackageShare('xarm_description'), 'urdf', 'xarm_device_with_table.urdf.xacro']))
         }.items(),
     )


### PR DESCRIPTION
## Summary
- add macro with floor and walls geometry
- include walls in xarm device URDF with new `add_walls` argument
- pass `add_walls` through launch files to ros2_control

## Testing
- `ros2 launch xarm_moveit_config single_xarm_rotary_moveit_realmove.launch.py add_walls:=true` *(fails: ros2 command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d7c77e3c832f9bab400e40af6fe0